### PR TITLE
Support arguments for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ which can be called to obtain the localized message by a given code, e. g.:
 $(".btn").text($L("default.btn.ok"));
 ```
 
+If you have a message with a placeholder, you can give the value to apply as an additional argument:
+
+```javascript
+$(".message").text($L("flash.message", "21"));
+```
+
+With multiple placeholders, you can give your values either as single arguments or as an array:
+
+```javascript
+$(".message").text($L("flash.message", "foo", "21"));
+$(".message").text($L("flash.message", ["foo", "21"]));
+```
+
 I18n file syntax
 ----------------
 

--- a/src/groovy/asset/pipeline/i18n/I18nProcessor.groovy
+++ b/src/groovy/asset/pipeline/i18n/I18nProcessor.groovy
@@ -116,9 +116,7 @@ class I18nProcessor extends AbstractProcessor {
      */
     @CompileStatic
     protected String compileJavaScript(Map<String, String> messages) {
-        StringBuilder buf = new StringBuilder('''(function (win) {
-    var messages = {
-''')
+        StringBuilder buf = new StringBuilder()
         int i = 0
         for (Map.Entry<String, String> entry in messages.entrySet()) {
             if (i++ > 0) {
@@ -130,15 +128,7 @@ class I18nProcessor extends AbstractProcessor {
                 .replace('"', '\\"')
             buf << '        "' << entry.key << '": "' << value << '"'
         }
-        buf << '''
-    }
-
-    win.$L = function (code) {
-        return messages[code];
-    }
-}(this));
-'''
-        buf.toString()
+        getClass().getResource('/resources/messages.js').text.replace('/*MESSAGES*/', buf.toString())
     }
 
     /**

--- a/src/java/resources/messages.js
+++ b/src/java/resources/messages.js
@@ -7,6 +7,23 @@
         var message = messages[code];
         if(message === undefined) {
             return "[" + code + "]";
+        } else if(message instanceof Array) {
+            var params;
+            if (arguments.length === 2 && (arguments[1]) instanceof Array) {
+                params = arguments[1];
+            } else {
+                params = Array.prototype.slice.call(arguments);
+                params.shift();
+            }
+            var result = "";
+            for(var i = 0; i < message.length; i++) {
+                if(typeof message[i] === "number") {
+                    result += params[message[i]];
+                } else {
+                    result += message[i];
+                }
+            }
+            return result;
         } else {
             return message;
         }

--- a/src/java/resources/messages.js
+++ b/src/java/resources/messages.js
@@ -4,6 +4,11 @@
     };
 
     win.$L = function (code) {
-        return messages[code];
+        var message = messages[code];
+        if(message === undefined) {
+            return "[" + code + "]";
+        } else {
+            return message;
+        }
     }
 }(this));

--- a/src/java/resources/messages.js
+++ b/src/java/resources/messages.js
@@ -1,0 +1,9 @@
+(function (win) {
+    var messages = {
+/*MESSAGES*/
+    };
+
+    win.$L = function (code) {
+        return messages[code];
+    }
+}(this));

--- a/test/unit/asset/pipeline/i18n/I18nProcessorSpec.groovy
+++ b/test/unit/asset/pipeline/i18n/I18nProcessorSpec.groovy
@@ -145,7 +145,7 @@ special.crlf''',
 ''')
         buf << messages
         buf << '''
-    }
+    };
 
     win.$L = function (code) {
         return messages[code];

--- a/test/unit/asset/pipeline/i18n/I18nProcessorSpec.groovy
+++ b/test/unit/asset/pipeline/i18n/I18nProcessorSpec.groovy
@@ -148,7 +148,12 @@ special.crlf''',
     };
 
     win.$L = function (code) {
-        return messages[code];
+        var message = messages[code];
+        if(message === undefined) {
+            return "[" + code + "]";
+        } else {
+            return message;
+        }
     }
 }(this));
 '''


### PR DESCRIPTION
Support arguments for messages in $L() (eg. `$L("example", ["foo", "bar"])`), like it's already possible with the message tag (eg. `<g:message code="example" args="${ ['foo', 'bar'] }" />`)
