### PR TITLE
Loading messages with encoding specified (utf-8 support)

### DIFF
--- a/src/test/groovy/asset/pipeline/i18n/I18nProcessorSpec.groovy
+++ b/src/test/groovy/asset/pipeline/i18n/I18nProcessorSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * I18nProcessorSpec.groovy
+ * I18nProcessor.groovy
  *
  * Copyright (c) 2014-2016, Daniel Ellermann
  *
@@ -19,139 +19,117 @@
 
 package asset.pipeline.i18n
 
+import asset.pipeline.AbstractProcessor
+import asset.pipeline.AssetCompiler
 import asset.pipeline.AssetFile
-import asset.pipeline.GenericAssetFile
-import org.springframework.core.io.InputStreamResource
+import grails.io.IOUtils
+import groovy.transform.CompileStatic
+import java.util.regex.Matcher
+import org.springframework.core.io.DefaultResourceLoader
 import org.springframework.core.io.Resource
 import org.springframework.core.io.ResourceLoader
-import spock.lang.Specification
 
 
-class I18nProcessorSpec extends Specification {
+/**
+ * The class {@code I18nProcessor} represents an asset processor which converts
+ * i18n file consisting of code keys to localized messages and builds a
+ * JavaScript file containing the function {@code $L} to obtain localized
+ * strings on client side.
+ * <p>
+ * I18n files must obey the following rules:
+ * <ul>
+ *   <li>The file name (without extension) must end with the locale
+ *   specification, e. g. {@code messages_de.i18n} or
+ * {@code msg_en_UK.i18n}.</li>
+ *   <li>The files are line based.</li>
+ *   <li>All lines are trimmed (that is, whitespaces are removed from beginning
+ *   and end of lines.</li>
+ *   <li>Empty lines and lines starting with a hash {@code #} (comment lines)
+ *   are ignored.</li>
+ *   <li>Lines starting with <code>@import <i>path</i></code> are replaced by
+ *   the content of the file with path <code><i>path</i></code>.  The suffix
+ * {@code .i18n} at path is optional and is appended automatically.</li>
+ *   <li>All other lines are treated as code keys which will be looked up in
+ *   Grails message resources for the locale specified in the file.</li>
+ * </ul>
+ *
+ * @author Daniel Ellermann
+ * @author David Estes
+ * @version 3.0
+ */
+@CompileStatic
+class I18nProcessor extends AbstractProcessor {
 
     //-- Constants ------------------------------
 
-    protected static final String MESSAGES = '''
-# Example message file
-foo.foo = Test
-foo.bar = Another test
-
-special.empty =
-special.backslash = Test \\\\{0\\\\}
-special.crlf = This is\\n\\
-        a test.
-special.quotationMarks = This is a "test".
-'''
-
+    protected static final String PROPERTIES_SUFFIX = '.properties'
+    protected static final String XML_SUFFIX = '.xml'
 
     //-- Fields ---------------------------------
 
-    AssetFile assetFile
-    I18nProcessor processor
+    ResourceLoader resourceLoader = new DefaultResourceLoader()
 
+    //-- Constructors ---------------------------
 
-    //-- Fixture methods ------------------------
-
-    def setup() {
-
-        // first create a i18n processor instance using this message file
-        processor = new I18nProcessor(null)
-        processor.resourceLoader = Mock(ResourceLoader)
-        processor.resourceLoader.getResource(_) >> new InputStreamResource(
-            new ByteArrayInputStream(MESSAGES.bytes)
-        )
-
-        // then create a mock asset file
-        assetFile = new GenericAssetFile(path: '/foo/bar/mymessages.i18n')
+    /**
+     * Creates a new i18n resource processor within the given asset
+     * pre-compiler.
+     *
+     * @param precompiler the given asset pre-compiler
+     */
+    I18nProcessor(AssetCompiler precompiler) {
+        super(precompiler)
     }
 
+    //-- Public methods -------------------------
 
-    //-- Feature methods ------------------------
+    @Override
+    String process(String inputText, AssetFile assetFile) {
+        Matcher m = assetFile.name =~ /._(\w+)\.i18n$/
+        StringBuilder buf = new StringBuilder('messages')
+        if (m) buf << '_' << m.group(1)
+        Properties props
+        if (assetFile.encoding != null) {
+            props = loadMessages(buf.toString(), assetFile.encoding)
+        } else {
+            props = loadMessages(buf.toString())
+        }
 
-    def 'Handle language files correctly'() {
-        given: 'an i18n processor'
-        def processor = new I18nProcessor(null)
+        // At this point, inputText has been pre-processed (I18nPreprocessor).
+        Map<String, String> messages = [:]
+        inputText.toString()
+                .eachLine { String line ->
+            if (line != '') {
+                messages.put line, props.getProperty(line, line)
+            }
+        }
 
-        and: 'a mocked resource'
-        Resource nonExistantResource = Mock()
-        nonExistantResource.exists() >> false
-
-        and: 'a mocked resource loader'
-        ResourceLoader resourceLoader = Mock()
-        1 * resourceLoader.getResource('messages_de.properties') >> nonExistantResource
-        1 * resourceLoader.getResource('messages_de.xml') >> nonExistantResource
-        1 * resourceLoader.getResource('file:grails-app/i18n/messages_de.properties') >>
-            new InputStreamResource(
-                new ByteArrayInputStream(MESSAGES.bytes)
-            )
-        0 * resourceLoader.getResource('file:grails-app/i18n/messages_de.xml')
-        processor.resourceLoader = resourceLoader
-
-        and: 'a localized mock asset file'
-        def assetFile = new GenericAssetFile(
-            path: '/foo/bar/mymessages_de.i18n'
-        )
-
-        when: 'I process an empty string'
-        String res = processor.process('', assetFile)
-
-        then: 'I do not get an error message'
-        '' != res
+        compileJavaScript messages
     }
-
-    def 'Process empty i18n file is possible'() {
-        when: 'I process an empty i18n file'
-        String res = processor.process('', assetFile)
-
-        then:
-        getJavaScriptCode('') == res
-    }
-
-    def 'Process i18n file with valid message codes is possible'() {
-        when: 'I process an i18n file containing valid message codes'
-        String res = processor.process('foo.bar\nfoo.foo', assetFile)
-
-        then:
-        getJavaScriptCode('''        "foo.bar": "Another test",
-        "foo.foo": "Test"''') == res
-    }
-
-    def 'Process i18n file with invalid message codes is possible'() {
-        when: 'I process an i18n file containing valid message codes'
-        String res = processor.process('foo.bar\nfoo.whee', assetFile)
-
-        then:
-        getJavaScriptCode('''        "foo.bar": "Another test",
-        "foo.whee": "foo.whee"''') == res
-    }
-
-    def 'Special characters have been escaped correctly'() {
-        when: 'I process an i18n file containing valid message codes'
-        String res = processor.process(
-            '''special.backslash
-special.empty
-special.quotationMarks
-special.crlf''',
-            assetFile
-        )
-
-        then:
-        getJavaScriptCode(
-            '''        "special.backslash": "Test \\\\{0\\\\}",
-        "special.empty": "",
-        "special.quotationMarks": "This is a \\"test\\".",
-        "special.crlf": "This is\\na test."'''
-            ) == res
-    }
-
 
     //-- Non-public methods ---------------------
 
-    private String getJavaScriptCode(String messages) {
+    /**
+     * Compiles JavaScript code from the given localized messages.
+     *
+     * @param messages the given messages
+     * @return the compiled JavaScript code
+     */
+    private String compileJavaScript(Map<String, String> messages) {
         StringBuilder buf = new StringBuilder('''(function (win) {
     var messages = {
 ''')
-        buf << messages
+        int i = 0
+        for (Map.Entry<String, String> entry in messages.entrySet()) {
+            if (i++ > 0) {
+                buf << ',\n'
+            }
+            String value = entry.value
+                    .replace('\\', '\\\\')
+                    .replace('\n', '\\n')
+                    .replace('"', '\\"')
+            buf << '        "' << entry.key << '": "' << value << '"'
+        }
         buf << '''
     }
 
@@ -160,7 +138,65 @@ special.crlf''',
     }
 }(this));
 '''
-
         buf.toString()
+    }
+
+    /**
+     * Loads the message resources from the given file.
+     *
+     * @param fileName the given base file name
+     * @return the read message resources
+     * @throws FileNotFoundException    if no resource with the required
+     *                                  localized messages exists
+     */
+    private Properties loadMessages(String fileName, String encoding = 'utf-8') {
+        Resource res = locateResource(fileName)
+        Properties props = new Properties()
+        String propertiesString = IOUtils.toString(res.inputStream, encoding)
+        props.load(new StringReader(propertiesString))
+
+        props
+    }
+
+    /**
+     * Locates the resource containing the localized messages.  The method looks
+     * in the following places:
+     * <ul>
+     *   <li>in classpath with extension {@code .properties}</li>
+     *   <li>in classpath with extension {@code .xml}</li>
+     *   <li>in file system in folder {@code grails-app/i18n} with extension
+     * {@code .properties}</li>
+     *   <li>in file system in folder {@code grails-app/i18n} with extension
+     * {@code .xml}</li>
+     * </ul>
+     *
+     * @param fileName the given base file name
+     * @return the resource containing the messages
+     * @throws FileNotFoundException    if no resource with the required
+     *                                  localized messages exists
+     */
+    private Resource locateResource(String fileName) {
+        Resource resource =
+                resourceLoader.getResource(fileName + PROPERTIES_SUFFIX)
+        if (!resource.exists()) {
+            resource = resourceLoader.getResource(fileName + XML_SUFFIX)
+        }
+        if (!resource.exists()) {
+            resource = resourceLoader.getResource(
+                    "file:grails-app/i18n/${fileName}${PROPERTIES_SUFFIX}"
+            )
+        }
+        if (!resource.exists()) {
+            resource = resourceLoader.getResource(
+                    "file:grails-app/i18n/${fileName}${XML_SUFFIX}"
+            )
+        }
+        if (!resource.exists()) {
+            throw new FileNotFoundException(
+                    "Cannot find i18n messages file ${fileName}."
+            )
+        }
+
+        resource
     }
 }


### PR DESCRIPTION
The prop files are always  ISO-8859-1 encoded so there is a problem if we want to use utf-8 translations. When loading the inputStream in properties I bypass it with creating String from the inputStream in the right encoding which then is loaded in the properties map.
